### PR TITLE
Set utilities category

### DIFF
--- a/Samra.xcodeproj/project.pbxproj
+++ b/Samra.xcodeproj/project.pbxproj
@@ -514,6 +514,7 @@
 				DEVELOPMENT_TEAM = L9735M962H;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Samra/Info.plist;
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				INFOPLIST_KEY_NSPrincipalClass = NSApplication;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -548,6 +549,7 @@
 				DEVELOPMENT_TEAM = L9735M962H;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Samra/Info.plist;
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				INFOPLIST_KEY_NSPrincipalClass = NSApplication;
 				LD_RUNPATH_SEARCH_PATHS = (


### PR DESCRIPTION
Currently, if you view your application list by category Samra is listed under Other. This PR sets the app's category to Utilities so it displays under the correct category in Finder.

![image](https://github.com/NSAntoine/Samra/assets/44692189/acc3107b-2dac-4d3f-9e37-8421b458bf4b)