### PR TITLE
Update Detail Items

### DIFF
--- a/Samra.xcodeproj/project.pbxproj
+++ b/Samra.xcodeproj/project.pbxproj
@@ -521,7 +521,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.15.1;
+				MACOSX_DEPLOYMENT_TARGET = 12.0;
 				MARKETING_VERSION = 1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.serena.Samra;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -556,7 +556,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.15.1;
+				MACOSX_DEPLOYMENT_TARGET = 12.0;
 				MARKETING_VERSION = 1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.serena.Samra;
 				PRODUCT_NAME = "$(TARGET_NAME)";


### PR DESCRIPTION
Restructuree a bit based on things that we are specifically interested in per type.
- Added UTI for Data
- Added Compression for Data and Images
- Added Data Size for Data
- Removed rendition name where it didn't make sense (Data and Color)
- Moved to macOS 12 to support byte formatting

<img width="737" alt="Screenshot 2024-08-11 at 13 53 20 PDT" src="https://github.com/user-attachments/assets/310e08c0-cc3e-4d7f-9f46-e179a8f2483c">
